### PR TITLE
Enabled QU and IV Stokes modes (issue #14)

### DIFF
--- a/cpp/skyweaver/CoherentBeamformer.cuh
+++ b/cpp/skyweaver/CoherentBeamformer.cuh
@@ -103,6 +103,10 @@ extern template class CoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::U>>;
 extern template class CoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::V>>;
+extern template class CoherentBeamformer<
+    StokesTraits<StokesParameter::Q, StokesParameter::U>>;
+extern template class CoherentBeamformer<
+    StokesTraits<StokesParameter::I, StokesParameter::V>>;
 extern template class CoherentBeamformer<FullStokesBeamformerTraits>;
 
 } // namespace skyweaver

--- a/cpp/skyweaver/IncoherentBeamformer.cuh
+++ b/cpp/skyweaver/IncoherentBeamformer.cuh
@@ -102,6 +102,10 @@ extern template class IncoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::U>>;
 extern template class IncoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::V>>;
+extern template class IncoherentBeamformer<
+    StokesTraits<StokesParameter::Q, StokesParameter::U>>;
+extern template class IncoherentBeamformer<
+    StokesTraits<StokesParameter::I, StokesParameter::V>>;
 extern template class IncoherentBeamformer<FullStokesBeamformerTraits>;
 
 } // namespace skyweaver

--- a/cpp/skyweaver/beamformer_utils.cuh
+++ b/cpp/skyweaver/beamformer_utils.cuh
@@ -168,20 +168,6 @@ template <> struct stokes_storage_type<4> {
 };
 
 /**
- * Helpers for getting the element type of the storage types
- * for sets of different Stokes parameters.
- */
-template <typename T> struct element_type {};
-template <> struct element_type<float> { using type = float; };
-template <> struct element_type<float2> { using type = float; };
-template <> struct element_type<float3> { using type = float; };
-template <> struct element_type<float4> { using type = float; };
-template <> struct element_type<int8_t> { using type = int8_t; };
-template <> struct element_type<char2>  { using type = int8_t; };
-template <> struct element_type<char3>  { using type = int8_t; };
-template <> struct element_type<char4>  { using type = int8_t; };
-
-/**
  * Helpers for getting the Nth value of a vector type by reference
  * An index of 0 turns into type::x, 1 --> type::y etc.
  * Direct usage of this struct should be avoided an instead the 
@@ -191,7 +177,7 @@ template <> struct element_type<char4>  { using type = int8_t; };
 template <typename T>
 struct accessor {
 	// Function to access members based on index
-	using base_type = typename element_type<std::decay_t<T>>::type;
+	using base_type = typename value_traits<std::decay_t<T>>::type;
 	using return_type = std::conditional_t<
 	                    std::is_const_v<std::remove_reference_t<T>>,
 	                    base_type const&,
@@ -310,7 +296,7 @@ struct Clamp {
 	template <int I, StokesParameter S, typename T, typename X>
 	static inline  __host__ __device__ void apply(T const& power, X& result)
 	{
-		using EType = typename element_type<X>::type;
+		using EType = typename value_traits<X>::type;
 		AT(result, I) = static_cast<EType>(
 		                    fmaxf(static_cast<float>(
 		                              std::numeric_limits<EType>::lowest()),

--- a/cpp/skyweaver/src/CoherentBeamformer.cu
+++ b/cpp/skyweaver/src/CoherentBeamformer.cu
@@ -277,6 +277,10 @@ template class CoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::U>>;
 template class CoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::V>>;
+template class CoherentBeamformer<
+    StokesTraits<StokesParameter::Q, StokesParameter::U>>;
+template class CoherentBeamformer<
+    StokesTraits<StokesParameter::I, StokesParameter::V>>;
 template class CoherentBeamformer<FullStokesBeamformerTraits>;
 
 } // namespace skyweaver

--- a/cpp/skyweaver/src/IncoherentBeamformer.cu
+++ b/cpp/skyweaver/src/IncoherentBeamformer.cu
@@ -189,6 +189,10 @@ template class IncoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::U>>;
 template class IncoherentBeamformer<
     SingleStokesBeamformerTraits<StokesParameter::V>>;
+template class IncoherentBeamformer<
+    StokesTraits<StokesParameter::Q, StokesParameter::U>>;
+template class IncoherentBeamformer<
+    StokesTraits<StokesParameter::I, StokesParameter::V>>;
 template class IncoherentBeamformer<FullStokesBeamformerTraits>;
 
 } // namespace skyweaver

--- a/cpp/skyweaver/src/IncoherentDedisperser.cu
+++ b/cpp/skyweaver/src/IncoherentDedisperser.cu
@@ -130,6 +130,16 @@ template void IncoherentDedisperser::dedisperse<
     thrust::host_vector<int8_t, PinnedAllocator<int8_t>> const& tfb_powers,
     TDBPowersH<int8_t>& tdb_powers);
 template void IncoherentDedisperser::dedisperse<
+    thrust::host_vector<char2, PinnedAllocator<char2>>,
+    TDBPowersH<char2>>(
+    thrust::host_vector<char2, PinnedAllocator<char2>> const& tfb_powers,
+    TDBPowersH<char2>& tdb_powers);
+template void IncoherentDedisperser::dedisperse<
+    thrust::host_vector<char3, PinnedAllocator<char3>>,
+    TDBPowersH<char3>>(
+    thrust::host_vector<char3, PinnedAllocator<char3>> const& tfb_powers,
+    TDBPowersH<char3>& tdb_powers);
+template void IncoherentDedisperser::dedisperse<
     thrust::host_vector<char4, PinnedAllocator<char4>>,
     TDBPowersH<char4>>(
     thrust::host_vector<char4, PinnedAllocator<char4>> const& tfb_powers,

--- a/cpp/skyweaver/src/skyweaver_cli.cu
+++ b/cpp/skyweaver/src/skyweaver_cli.cu
@@ -531,13 +531,21 @@ int main(int argc, char** argv)
                 setup_pipeline<skyweaver::SingleStokesBeamformerTraits<
                                    skyweaver::StokesParameter::V>,
                                true>(config);
+            } else if(config.stokes_mode() == "QU") {
+                setup_pipeline<skyweaver::StokesTraits<
+                                   skyweaver::StokesParameter::Q, skyweaver::StokesParameter::U>,
+                               true>(config);
+            } else if(config.stokes_mode() == "IV") {
+                setup_pipeline<skyweaver::StokesTraits<
+                                   skyweaver::StokesParameter::I, skyweaver::StokesParameter::V>,
+                               true>(config);             
             } else if(config.stokes_mode() == "IQUV") {
                 setup_pipeline<skyweaver::FullStokesBeamformerTraits, true>(
                     config);
             } else {
                 throw std::runtime_error(
                     "Invalid Stokes mode passed, must be one "
-                    "of I, Q, U, V or IQUV");
+                    "of I, Q, U, V, QU, IV or IQUV");
             }
         } else {
             BOOST_LOG_TRIVIAL(info) << "Incoherent dedispersion disabled";
@@ -557,13 +565,21 @@ int main(int argc, char** argv)
                 setup_pipeline<skyweaver::SingleStokesBeamformerTraits<
                                    skyweaver::StokesParameter::V>,
                                false>(config);
+            } else if(config.stokes_mode() == "QU") {
+                setup_pipeline<skyweaver::StokesTraits<
+                                   skyweaver::StokesParameter::Q, skyweaver::StokesParameter::U>,
+                               false>(config);
+            } else if(config.stokes_mode() == "IV") {
+                setup_pipeline<skyweaver::StokesTraits<
+                                   skyweaver::StokesParameter::I, skyweaver::StokesParameter::V>,
+                               false>(config); 
             } else if(config.stokes_mode() == "IQUV") {
                 setup_pipeline<skyweaver::FullStokesBeamformerTraits, false>(
                     config);
             } else {
                 throw std::runtime_error(
                     "Invalid Stokes mode passed, must be one "
-                    "of I, Q, U, V or IQUV");
+                    "of I, Q, U, V, QU, IV or IQUV");
             }
         }
     } catch(std::exception& e) {

--- a/cpp/skyweaver/test/BeamformerPipelineTester.cuh
+++ b/cpp/skyweaver/test/BeamformerPipelineTester.cuh
@@ -11,6 +11,7 @@ namespace skyweaver
 namespace test
 {
 
+template <typename BfTraits>
 class BeamformerPipelineTester: public ::testing::Test
 {
   
@@ -19,6 +20,7 @@ class BeamformerPipelineTester: public ::testing::Test
     void TearDown() override;
 
   public:
+    using BfTraitsType = BfTraits;
     BeamformerPipelineTester();
     ~BeamformerPipelineTester();
   protected:

--- a/cpp/skyweaver/test/src/CoherentBeamformerTester.cu
+++ b/cpp/skyweaver/test/src/CoherentBeamformerTester.cu
@@ -197,6 +197,8 @@ typedef ::testing::Types<SingleStokesBeamformerTraits<StokesParameter::I>,
                          SingleStokesBeamformerTraits<StokesParameter::Q>,
                          SingleStokesBeamformerTraits<StokesParameter::U>,
                          SingleStokesBeamformerTraits<StokesParameter::V>,
+                         StokesTraits<StokesParameter::Q, StokesParameter::U>,
+                         StokesTraits<StokesParameter::I, StokesParameter::V>,
                          FullStokesBeamformerTraits>
     StokesTypes;
 TYPED_TEST_SUITE(CoherentBeamformerTester, StokesTypes);

--- a/cpp/skyweaver/test/src/IncoherentBeamformerTester.cu
+++ b/cpp/skyweaver/test/src/IncoherentBeamformerTester.cu
@@ -147,6 +147,8 @@ typedef ::testing::Types<SingleStokesBeamformerTraits<StokesParameter::I>,
                          SingleStokesBeamformerTraits<StokesParameter::Q>,
                          SingleStokesBeamformerTraits<StokesParameter::U>,
                          SingleStokesBeamformerTraits<StokesParameter::V>,
+                         StokesTraits<StokesParameter::Q, StokesParameter::U>,
+                         StokesTraits<StokesParameter::I, StokesParameter::V>,
                          FullStokesBeamformerTraits>
     StokesTypes;
 TYPED_TEST_SUITE(IncoherentBeamformerTester, StokesTypes);

--- a/cpp/skyweaver/test/src/IncoherentDedisperserTester.cu
+++ b/cpp/skyweaver/test/src/IncoherentDedisperserTester.cu
@@ -32,6 +32,8 @@ void IncoherentDedisperserTester<Traits>::TearDown()
 }
 
 typedef ::testing::Types<IDTesterTraits<int8_t, int8_t>,
+                         IDTesterTraits<char2, char2>,
+                         IDTesterTraits<char3, char3>,
                          IDTesterTraits<char4, char4>>
     TestTypes;
 TYPED_TEST_SUITE(IncoherentDedisperserTester, TestTypes);

--- a/cpp/skyweaver/test/test_utils.cuh
+++ b/cpp/skyweaver/test/test_utils.cuh
@@ -81,13 +81,17 @@ expect_near(T const& a, T const& b, X const& c)
 }
 
 template <typename T, typename X>
-typename std::enable_if<is_vec4_v<T>, void>::type
+typename std::enable_if<is_vecN_v<T>, void>::type
 expect_near(T const& a, T const& b, X const& c)
 {
     EXPECT_NEAR(a.x, b.x, c);
     EXPECT_NEAR(a.y, b.y, c);
-    EXPECT_NEAR(a.z, b.z, c);
-    EXPECT_NEAR(a.w, b.w, c);
+    if constexpr (value_traits<T>::size() > 2){
+        EXPECT_NEAR(a.z, b.z, c);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        EXPECT_NEAR(a.w, b.w, c);
+    }
 }
 
 template <typename T, typename X>
@@ -98,13 +102,17 @@ expect_relatively_near(T const& a, T const& b, X const& c)
 }
 
 template <typename T, typename X>
-typename std::enable_if<is_vec4_v<T>, void>::type
+typename std::enable_if<is_vecN_v<T>, void>::type
 expect_relatively_near(T const& a, T const& b, X const& c)
 {
     EXPECT_NEAR(a.x, b.x, std::abs(a.x * c));
     EXPECT_NEAR(a.y, b.y, std::abs(a.y * c));
-    EXPECT_NEAR(a.z, b.z, std::abs(a.z * c));
-    EXPECT_NEAR(a.w, b.w, std::abs(a.w * c));
+    if constexpr (value_traits<T>::size() > 2){
+        EXPECT_NEAR(a.z, b.z, std::abs(a.z * c));
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        EXPECT_NEAR(a.w, b.w, std::abs(a.w * c));
+    }
 }
 
 template <typename T>

--- a/cpp/skyweaver/types.cuh
+++ b/cpp/skyweaver/types.cuh
@@ -7,20 +7,20 @@
 #include <iostream>
 
 // Operator overloading for CUDA vector types
-template <typename T>
-struct is_vec4: std::false_type {
-};
 
-template <>
-struct is_vec4<float4>: std::true_type {
-};
-
-template <>
-struct is_vec4<char4>: std::true_type {
-};
 
 template <typename T>
-inline constexpr bool is_vec4_v = is_vec4<T>::value;
+struct is_vecN : std::disjunction<
+                    std::is_same<T, float2>,
+                    std::is_same<T, float3>,    
+                    std::is_same<T, float4>,
+                    std::is_same<T, char2>,
+                    std::is_same<T, char3>,
+                    std::is_same<T, char4>
+                > {};
+
+template <typename T>
+inline constexpr bool is_vecN_v = is_vecN<T>::value;
 
 template <typename T>
 struct value_traits {
@@ -30,30 +30,82 @@ template <>
 struct value_traits<int8_t> {
     typedef int8_t type;
     typedef float promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 1; }
     __host__ __device__ static constexpr int8_t zero() { return 0; }
     __host__ __device__ static constexpr int8_t one() { return 1; }
 };
 
 template <>
-struct value_traits<float> {
-    typedef float type;
-    typedef float promoted_type;
-    __host__ __device__ static constexpr float zero() { return 0.0f; }
-    __host__ __device__ static constexpr float one() { return 1.0f; }
+struct value_traits<char2> {
+    typedef int8_t type;
+    typedef float2 promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 2; }
+    __host__ __device__ static constexpr char2 zero() { return {0, 0}; }
+    __host__ __device__ static constexpr char2 one() { return {1, 1}; }
+};
+
+template <>
+struct value_traits<char3> {
+    typedef int8_t type;
+    typedef float3 promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 3; }
+    __host__ __device__ static constexpr char3 zero() { return {0, 0, 0}; }
+    __host__ __device__ static constexpr char3 one() { return {1, 1, 1}; }
 };
 
 template <>
 struct value_traits<char4> {
     typedef int8_t type;
     typedef float4 promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 4; }
     __host__ __device__ static constexpr char4 zero() { return {0, 0, 0, 0}; }
     __host__ __device__ static constexpr char4 one() { return {1, 1, 1, 1}; }
+};
+
+template <>
+struct value_traits<float> {
+    typedef float type;
+    typedef float promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 1; }
+    __host__ __device__ static constexpr float zero() { return 0.0f; }
+    __host__ __device__ static constexpr float one() { return 1.0f; }
+};
+
+template <>
+struct value_traits<float2> {
+    typedef float type;
+    typedef float2 promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 2; }
+    __host__ __device__ static constexpr float2 zero()
+    {
+        return {0.0f, 0.0f};
+    }
+    __host__ __device__ static constexpr float2 one()
+    {
+        return {1.0f, 1.0f};
+    }
+};
+
+template <>
+struct value_traits<float3> {
+    typedef float type;
+    typedef float3 promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 3; }
+    __host__ __device__ static constexpr float3 zero()
+    {
+        return {0.0f, 0.0f, 0.0f};
+    }
+    __host__ __device__ static constexpr float3 one()
+    {
+        return {1.0f, 1.0f, 1.0f};
+    }
 };
 
 template <>
 struct value_traits<float4> {
     typedef float type;
     typedef float4 promoted_type;
+    __host__ __device__ static constexpr int8_t size() { return 4; }
     __host__ __device__ static constexpr float4 zero()
     {
         return {0.0f, 0.0f, 0.0f, 0.0f};
@@ -64,11 +116,37 @@ struct value_traits<float4> {
     }
 };
 
+inline std::ostream& operator<<(std::ostream& stream, char2 const& val)
+{
+    stream << "(" << static_cast<int>(val.x) << "," << static_cast<int>(val.y)
+           << ")";
+    return stream;
+}
+
+inline std::ostream& operator<<(std::ostream& stream, char3 const& val)
+{
+    stream << "(" << static_cast<int>(val.x) << "," << static_cast<int>(val.y)
+           << "," << static_cast<int>(val.z) << ")";
+    return stream;
+}
+
 inline std::ostream& operator<<(std::ostream& stream, char4 const& val)
 {
     stream << "(" << static_cast<int>(val.x) << "," << static_cast<int>(val.y)
            << "," << static_cast<int>(val.z) << "," << static_cast<int>(val.w)
            << ")";
+    return stream;
+}
+
+inline std::ostream& operator<<(std::ostream& stream, float2 const& val)
+{
+    stream << "(" << val.x << "," << val.y << ")";
+    return stream;
+}
+
+inline std::ostream& operator<<(std::ostream& stream, float3 const& val)
+{
+    stream << "(" << val.x << "," << val.y << "," << val.z << ")";
     return stream;
 }
 
@@ -84,69 +162,105 @@ inline std::ostream& operator<<(std::ostream& stream, float4 const& val)
  * explicit static_casts used to avoid Wnarrowing errors for int8_t types due to
  * integral promotion (over/underflow is the expected behaviour here).
  */
-template <typename T, typename X>
-__host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<X>, T>::type
-    operator+(const T& lhs, const X& rhs)
-{
-    return {static_cast<typename value_traits<T>::type>(lhs.x + rhs.x),
-            static_cast<typename value_traits<T>::type>(lhs.y + rhs.y),
-            static_cast<typename value_traits<T>::type>(lhs.z + rhs.z),
-            static_cast<typename value_traits<T>::type>(lhs.w + rhs.w)};
-}
+
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<X>, T>::type operator+(const T& lhs, const X& rhs)
+{
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x + rhs.x);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y + rhs.y);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z + rhs.z);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w + rhs.w);
+    }
+    return r;
+}
+
+
+template <typename T, typename X>
+__host__ __device__ inline
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<X>, T>::type
     operator+=(T& lhs, const X& rhs)
 {
     lhs.x += rhs.x;
     lhs.y += rhs.y;
-    lhs.z += rhs.z;
-    lhs.w += rhs.w;
+    if constexpr (value_traits<T>::size() > 2){
+        lhs.z += rhs.z;
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        lhs.w += rhs.w;
+    }
     return lhs;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<X>, T>::type
     operator-(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x - rhs.x),
-            static_cast<typename value_traits<T>::type>(lhs.y - rhs.y),
-            static_cast<typename value_traits<T>::type>(lhs.z - rhs.z),
-            static_cast<typename value_traits<T>::type>(lhs.w - rhs.w)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x - rhs.x);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y - rhs.y);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z - rhs.z);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w - rhs.w);
+    }
+    return r;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<X>, T>::type
     operator*(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x * rhs.x),
-            static_cast<typename value_traits<T>::type>(lhs.y * rhs.y),
-            static_cast<typename value_traits<T>::type>(lhs.z * rhs.z),
-            static_cast<typename value_traits<T>::type>(lhs.w * rhs.w)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x * rhs.x);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y * rhs.y);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z * rhs.z);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w * rhs.w);
+    }
+    return r;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<X>, T>::type
     operator/(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x / rhs.x),
-            static_cast<typename value_traits<T>::type>(lhs.y / rhs.y),
-            static_cast<typename value_traits<T>::type>(lhs.z / rhs.z),
-            static_cast<typename value_traits<T>::type>(lhs.w / rhs.w)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x / rhs.x);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y / rhs.y);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z / rhs.z);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w / rhs.w);
+    }
+    return r;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<X>, bool>::type
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<X>, bool>::type
     operator==(const T& lhs, const X& rhs)
 {
-    return (lhs.x == rhs.x) && (lhs.y == rhs.y) && (lhs.z == rhs.z) &&
-           (lhs.w == rhs.w);
+    bool r = (lhs.x == rhs.x) && (lhs.y == rhs.y);
+    if constexpr (value_traits<T>::size() > 2){
+        r = r && (lhs.z == rhs.z);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r = r && (lhs.w == rhs.w);
+    }
+    return r;
 }
 
 /**
@@ -154,58 +268,86 @@ __host__ __device__ inline
  */
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && std::is_arithmetic_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && std::is_arithmetic_v<X>, T>::type
     operator*(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x * rhs),
-            static_cast<typename value_traits<T>::type>(lhs.y * rhs),
-            static_cast<typename value_traits<T>::type>(lhs.z * rhs),
-            static_cast<typename value_traits<T>::type>(lhs.w * rhs)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x * rhs);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y * rhs);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z * rhs);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w * rhs);
+    }
+    return r;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && std::is_arithmetic_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && std::is_arithmetic_v<X>, T>::type
     operator+=(const T& lhs, const X& rhs)
 {
     lhs.x += rhs;
     lhs.y += rhs;
-    lhs.z += rhs;
-    lhs.w += rhs;
+    if constexpr (value_traits<T>::size() > 2){
+        lhs.z += rhs;
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        lhs.w += rhs;
+    }
     return lhs;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && std::is_arithmetic_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && std::is_arithmetic_v<X>, T>::type
     operator/(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x / rhs),
-            static_cast<typename value_traits<T>::type>(lhs.y / rhs),
-            static_cast<typename value_traits<T>::type>(lhs.z / rhs),
-            static_cast<typename value_traits<T>::type>(lhs.w / rhs)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x / rhs);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y / rhs);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z / rhs);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w / rhs);
+    }
+    return r;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && std::is_arithmetic_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && std::is_arithmetic_v<X>, T>::type
     operator+(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x + rhs),
-            static_cast<typename value_traits<T>::type>(lhs.y + rhs),
-            static_cast<typename value_traits<T>::type>(lhs.z + rhs),
-            static_cast<typename value_traits<T>::type>(lhs.w + rhs)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x + rhs);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y + rhs);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z + rhs);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w + rhs);
+    }
+    return r;
 }
 
 template <typename T, typename X>
 __host__ __device__ inline
-    typename std::enable_if<is_vec4_v<T> && std::is_arithmetic_v<X>, T>::type
+    typename std::enable_if<is_vecN_v<T> && std::is_arithmetic_v<X>, T>::type
     operator-(const T& lhs, const X& rhs)
 {
-    return {static_cast<typename value_traits<T>::type>(lhs.x - rhs),
-            static_cast<typename value_traits<T>::type>(lhs.y - rhs),
-            static_cast<typename value_traits<T>::type>(lhs.z - rhs),
-            static_cast<typename value_traits<T>::type>(lhs.w - rhs)};
+    T r;
+    r.x = static_cast<typename value_traits<T>::type>(lhs.x - rhs);
+    r.y = static_cast<typename value_traits<T>::type>(lhs.y - rhs);
+    if constexpr (value_traits<T>::size() > 2){
+        r.z = static_cast<typename value_traits<T>::type>(lhs.z - rhs);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        r.w = static_cast<typename value_traits<T>::type>(lhs.w - rhs);
+    }
+    return r;
 }
 
 template <typename U, typename T>
@@ -222,7 +364,7 @@ __host__ __device__ static inline
 
 template <typename U, typename T>
 __host__ __device__ static inline
-    typename std::enable_if<is_vec4_v<T> && is_vec4_v<U>, U>::type
+    typename std::enable_if<is_vecN_v<T> && is_vecN_v<U>, U>::type
     clamp(T const& value)
 {
     U clamped;
@@ -232,12 +374,16 @@ __host__ __device__ static inline
     clamped.y =
         clamp<typename value_traits<U>::type, typename value_traits<T>::type>(
             value.y);
-    clamped.z =
-        clamp<typename value_traits<U>::type, typename value_traits<T>::type>(
-            value.z);
-    clamped.w =
-        clamp<typename value_traits<U>::type, typename value_traits<T>::type>(
-            value.w);
+    if constexpr (value_traits<T>::size() > 2){
+        clamped.z =
+            clamp<typename value_traits<U>::type, typename value_traits<T>::type>(
+                value.z);
+    }
+    if constexpr (value_traits<T>::size() > 3){
+        clamped.w =
+            clamp<typename value_traits<U>::type, typename value_traits<T>::type>(
+                value.w);
+    }
     return clamped;
 }
 


### PR DESCRIPTION
I've update the stokes traits handling to enable arbitrary combinations of stokes parameters. However on QU and IV have been explicitly added to the CLI as it doesn't make sense to compile permuations that won't be used.