### PR TITLE
Add a pausing mechanism to avoid the code from crashing, if the disk runs full.

### DIFF
--- a/cpp/skyweaver/FileOutputStream.hpp
+++ b/cpp/skyweaver/FileOutputStream.hpp
@@ -2,7 +2,6 @@
 #define SKYWEAVER_FILEOUTPUTSTREAM_HPP
 
 #include "boost/log/trivial.hpp"
-#include "skyweaver/PipelineConfig.hpp"
 
 #include <fstream>
 #include <functional>
@@ -43,11 +42,10 @@ class FileOutputStream
          *
          * @return     The number of bytes written in this execution
          */
-        std::size_t write(PipelineConfig const& config, char const* ptr, std::size_t bytes);
-        void wait_for_space(PipelineConfig const& config, size_t requested_bytes);
+        std::size_t write(char const* ptr, std::size_t bytes);
+
       private:
         std::string _full_path;
-        PipelineConfig _config;
         std::size_t _bytes_requested;
         std::size_t _bytes_written;
         std::ofstream _stream;
@@ -65,7 +63,7 @@ class FileOutputStream
      * @param[in]  header_updater  A callback used to get updates to the header
      * so that it can be kept up to date based on the amount of data written.
      */
-    explicit FileOutputStream(PipelineConfig const& config, std::string const& directory,
+    explicit FileOutputStream(std::string const& directory,
                         std::string const& base_filename,
                         std::string const& extension,
                         std::size_t bytes_per_file,
@@ -98,7 +96,6 @@ class FileOutputStream
     std::size_t _total_bytes_written;
     std::unique_ptr<File> _current_file;
     std::size_t _file_count;
-    PipelineConfig const& _config;
 };
 
 } // namespace skyweaver

--- a/cpp/skyweaver/FileOutputStream.hpp
+++ b/cpp/skyweaver/FileOutputStream.hpp
@@ -2,6 +2,7 @@
 #define SKYWEAVER_FILEOUTPUTSTREAM_HPP
 
 #include "boost/log/trivial.hpp"
+#include "skyweaver/PipelineConfig.hpp"
 
 #include <fstream>
 #include <functional>
@@ -42,12 +43,11 @@ class FileOutputStream
          *
          * @return     The number of bytes written in this execution
          */
-        std::size_t write(char const* ptr, std::size_t bytes);
-
-      private:
-        void wait_for_space(size_t requested_bytes);
+        std::size_t write(PipelineConfig const& config, char const* ptr, std::size_t bytes);
+        void wait_for_space(PipelineConfig const& config, size_t requested_bytes);
       private:
         std::string _full_path;
+        PipelineConfig _config;
         std::size_t _bytes_requested;
         std::size_t _bytes_written;
         std::ofstream _stream;
@@ -65,7 +65,7 @@ class FileOutputStream
      * @param[in]  header_updater  A callback used to get updates to the header
      * so that it can be kept up to date based on the amount of data written.
      */
-    explicit FileOutputStream(std::string const& directory,
+    explicit FileOutputStream(PipelineConfig const& config, std::string const& directory,
                         std::string const& base_filename,
                         std::string const& extension,
                         std::size_t bytes_per_file,
@@ -98,6 +98,7 @@ class FileOutputStream
     std::size_t _total_bytes_written;
     std::unique_ptr<File> _current_file;
     std::size_t _file_count;
+    PipelineConfig const& _config;
 };
 
 } // namespace skyweaver

--- a/cpp/skyweaver/FileOutputStream.hpp
+++ b/cpp/skyweaver/FileOutputStream.hpp
@@ -45,6 +45,8 @@ class FileOutputStream
         std::size_t write(char const* ptr, std::size_t bytes);
 
       private:
+        void wait_for_space(size_t requested_bytes);
+      private:
         std::string _full_path;
         std::size_t _bytes_requested;
         std::size_t _bytes_written;

--- a/cpp/skyweaver/MultiFileWriter.cuh
+++ b/cpp/skyweaver/MultiFileWriter.cuh
@@ -20,6 +20,7 @@ template <typename VectorType>
 class MultiFileWriter
 {
   public:
+     using PreWriteCallback = std::function<void(std::size_t, PipelineConfig const&)>;
     /**
      * @brief Construct a new Multi File Writer object
      *
@@ -28,6 +29,8 @@ class MultiFileWriter
      *                (used to avoid clashing file names).
      */
     MultiFileWriter(PipelineConfig const& config, std::string tag = "");
+    MultiFileWriter(PipelineConfig const& config, PreWriteCallback&& callback,
+                    std::string tag = " ");
     MultiFileWriter(MultiFileWriter const&) = delete;
 
     /**
@@ -71,13 +74,13 @@ class MultiFileWriter
     std::string get_basefilename(VectorType const& stream_data,
                                  std::size_t stream_idx);
     std::string get_extension(VectorType const& stream_data);
-    void wait_for_space(size_t size);
     PipelineConfig const& _config;
     std::string _tag;
     ObservationHeader _header;
     std::map<std::size_t, std::unique_ptr<FileOutputStream>> _file_streams;
     std::map<std::size_t, std::vector<std::size_t>> _stream_dims;
     std::vector<long double> _dm_delays;
+    PreWriteCallback _pre_write_callback;
 };
 
 } // namespace skyweaver

--- a/cpp/skyweaver/MultiFileWriter.cuh
+++ b/cpp/skyweaver/MultiFileWriter.cuh
@@ -71,7 +71,7 @@ class MultiFileWriter
     std::string get_basefilename(VectorType const& stream_data,
                                  std::size_t stream_idx);
     std::string get_extension(VectorType const& stream_data);
-
+    void wait_for_space();
     PipelineConfig const& _config;
     std::string _tag;
     ObservationHeader _header;

--- a/cpp/skyweaver/MultiFileWriter.cuh
+++ b/cpp/skyweaver/MultiFileWriter.cuh
@@ -71,7 +71,7 @@ class MultiFileWriter
     std::string get_basefilename(VectorType const& stream_data,
                                  std::size_t stream_idx);
     std::string get_extension(VectorType const& stream_data);
-    void wait_for_space();
+    void wait_for_space(size_t size);
     PipelineConfig const& _config;
     std::string _tag;
     ObservationHeader _header;

--- a/cpp/skyweaver/PipelineConfig.hpp
+++ b/cpp/skyweaver/PipelineConfig.hpp
@@ -161,6 +161,11 @@ class PipelineConfig
     DedispersionPlan const& ddplan() const;
 
     /**
+     * @brief      configures wait for filesystem space
+     */
+    void configure_wait(std::string argument);
+
+    /**
      * @brief      Enable/disable incoherent dedispersion based fscrunch after
      * beamforming
      */

--- a/cpp/skyweaver/PipelineConfig.hpp
+++ b/cpp/skyweaver/PipelineConfig.hpp
@@ -15,6 +15,13 @@ namespace skyweaver
  */
 class PipelineConfig
 {
+  struct WaitStruct
+  {
+    bool is_enabled;
+    int iterations;
+    int sleep_time;
+    std::size_t min_free_space;
+  };
   public:
     PipelineConfig();
     ~PipelineConfig();

--- a/cpp/skyweaver/PipelineConfig.hpp
+++ b/cpp/skyweaver/PipelineConfig.hpp
@@ -333,8 +333,16 @@ class PipelineConfig
     {
         return SKYWEAVER_NSAMPLES_PER_HEAP;
     }
+    /**
+     * @brief Returns the wait config
+     */
+    WaitStruct get_wait_config() const
+    {
+        return _wait;
+    }
 
   private:
+    std::size_t convertMemorySize(const std::string& str) const;
     void calculate_channel_frequencies() const;
     void update_power_offsets_and_scalings();
 
@@ -361,6 +369,7 @@ class PipelineConfig
     std::string _stokes_mode;
     float _output_level;
     DedispersionPlan _ddplan;
+    WaitStruct _wait;
     mutable std::vector<double> _channel_frequencies;
 };
 

--- a/cpp/skyweaver/detail/MultiFileWriter.cu
+++ b/cpp/skyweaver/detail/MultiFileWriter.cu
@@ -290,7 +290,7 @@ void MultiFileWriter<VectorType>::wait_for_space()
     if(space.available >= _config.get_wait_config().min_free_space)
         return;
 
-    BOOST_LOG_TRIVIAL(warning)
+    BOOST_LOG_TRIVIAL(info)
         << space.available
         << " bytes available space is not enough for configured minimum of "
         << _config.get_wait_config().min_free_space
@@ -303,7 +303,7 @@ void MultiFileWriter<VectorType>::wait_for_space()
         space = std::filesystem::space(_config.output_dir());
         if (space.available >= _config.get_wait_config().min_free_space)
         {
-          BOOST_LOG_TRIVIAL(warning) << "Space has been freed up. Will proceed.";
+          BOOST_LOG_TRIVIAL(info) << "Space has been freed up. Will proceed.";
           return;
         }
     }

--- a/cpp/skyweaver/detail/MultiFileWriter.cu
+++ b/cpp/skyweaver/detail/MultiFileWriter.cu
@@ -280,7 +280,7 @@ void MultiFileWriter<VectorType>::wait_for_space()
         << _config.get_wait_config().min_free_space
         << " bytes to " << _config.output_dir() << ".";
     BOOST_LOG_TRIVIAL(warning) << "Start pausing.";
-    int max_interations = (_config.get_wait_config().iterations == 0) ? INT_MAX : _config.get_wait_config().iterations;
+    int max_iterations = (_config.get_wait_config().iterations == 0) ? INT_MAX : _config.get_wait_config().iterations;
     for (int i = 0; i < max_iterations; i++)
     {
         sleep(_config.get_wait_config().sleep_time);

--- a/cpp/skyweaver/detail/MultiFileWriter.cu
+++ b/cpp/skyweaver/detail/MultiFileWriter.cu
@@ -115,6 +115,7 @@ MultiFileWriter<VectorType>::create_stream(VectorType const& stream_data,
         << "Maximum allowed file size = " << filesize << " bytes (+header)";
 
     _file_streams[stream_idx] = std::make_unique<FileOutputStream>(
+        _config,
         get_output_dir(stream_data, stream_idx),
         get_basefilename(stream_data, stream_idx),
         get_extension(stream_data),

--- a/cpp/skyweaver/detail/MultiFileWriter.cu
+++ b/cpp/skyweaver/detail/MultiFileWriter.cu
@@ -280,8 +280,8 @@ void MultiFileWriter<VectorType>::wait_for_space()
         << _config.get_wait_config().min_free_space
         << " bytes to " << _config.output_dir() << ".";
     BOOST_LOG_TRIVIAL(warning) << "Start pausing.";
-    int incrementor = (_config.get_wait_config().iterations == 0) ? 0 : 1;
-    for (int i = 0; i < _config.get_wait_config().iterations; i+= incrementor)
+    int max_interations = (_config.get_wait_config().iterations == 0) ? INT_MAX : _config.get_wait_config().iterations;
+    for (int i = 0; i < max_iterations; i++)
     {
         sleep(_config.get_wait_config().sleep_time);
         space = std::filesystem::space(_config.output_dir());

--- a/cpp/skyweaver/src/FileOutputStream.cpp
+++ b/cpp/skyweaver/src/FileOutputStream.cpp
@@ -107,7 +107,8 @@ void FileOutputStream::File::wait_for_space(size_t requested_bytes)
     BOOST_LOG_TRIVIAL(warning) << "Space has been freed up. Will proceed.";
 }
 
-FileOutputStream::FileOutputStream(std::string const& directory,
+FileOutputStream::FileOutputStream(PipelineConfig const& config,
+                       std::string const& directory,
                        std::string const& base_filename,
                        std::string const& extension,
                        std::size_t bytes_per_file,
@@ -115,7 +116,7 @@ FileOutputStream::FileOutputStream(std::string const& directory,
     : _directory(directory), _base_filename(base_filename),
       _extension(extension), _bytes_per_file(bytes_per_file),
       _header_update_callback(header_update_callback), _total_bytes_written(0),
-      _current_file(nullptr), _file_count(0)
+      _current_file(nullptr), _file_count(0), _config(config)
 {
     if(_bytes_per_file == 0) {
         throw std::runtime_error(

--- a/cpp/skyweaver/src/FileOutputStream.cpp
+++ b/cpp/skyweaver/src/FileOutputStream.cpp
@@ -50,7 +50,7 @@ FileOutputStream::File::~File()
     }
 }
 
-std::size_t FileOutputStream::File::write(char const* ptr, std::size_t bytes)
+std::size_t FileOutputStream::File::write(PipelineConfig const& config, char const* ptr, std::size_t bytes)
 {
     BOOST_LOG_TRIVIAL(debug)
         << "Writing " << bytes << " bytes to " << _full_path;
@@ -88,7 +88,7 @@ std::size_t FileOutputStream::File::write(char const* ptr, std::size_t bytes)
     }
 }
 
-void FileOutputStream::File::wait_for_space(size_t requested_bytes)
+void FileOutputStream::File::wait_for_space(PipelineConfig const& config, size_t requested_bytes)
 {
     std::filesystem::space_info space = std::filesystem::space(_full_path);
     if(space.available >= requested_bytes)

--- a/cpp/skyweaver/src/FileOutputStream.cpp
+++ b/cpp/skyweaver/src/FileOutputStream.cpp
@@ -88,7 +88,7 @@ std::size_t FileOutputStream::File::write(char const* ptr, std::size_t bytes)
     }
 }
 
-FileOUtputStream::File::wait_for_space(size_t requested_bytes)
+void FileOutputStream::File::wait_for_space(size_t requested_bytes)
 {
     std::filesystem::space_info space = std::filesystem::space(_full_path);
     if(space.available >= requested_bytes)

--- a/cpp/skyweaver/src/PipelineConfig.cpp
+++ b/cpp/skyweaver/src/PipelineConfig.cpp
@@ -157,6 +157,47 @@ DedispersionPlan const& PipelineConfig::ddplan() const
     return _ddplan;
 }
 
+std::size_t PipelineConfig::convertMemorySize(const std::string& str) const {
+    std::size_t lastCharPos = str.find_last_not_of("0123456789");
+    std::string numberPart = str.substr(0, lastCharPos);
+    std::string unitPart = str.substr(lastCharPos);
+
+    std::size_t number = std::stoull(numberPart);
+
+    if (unitPart.empty())
+        return number;
+    else if (unitPart == "K" || unitPart == "k")
+        return number * 1024;
+    else if (unitPart == "M" || unitPart == "m")
+        return number * 1024 * 1024;
+    else if (unitPart == "G" || unitPart == "g")
+        return number * 1024 * 1024 * 1024;
+    else
+        throw std::runtime_error("Invalid unit!");
+}
+
+void PipelineConfig::configure_wait(std::string argument)
+{
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(argument);
+    int indx = 0;
+    _wait.is_enabled = true;
+    while (std::getline(tokenStream, token, ':')) {
+        if(indx == 0)
+            _wait.iterations = std::stoi(token);
+        else if(indx == 1)
+            _wait.sleep_time = std::stoi(token);
+        else if(indx == 2)
+            if (!token.empty() && std::all_of(token.begin(), token.end(), ::isdigit))
+            {
+               _wait.min_free_space = std::stoull(token);
+            } else {
+               _wait.min_free_space = convertMemorySize(token);
+            }
+        indx++;
+    }
+}
 
 
 void PipelineConfig::enable_incoherent_dedispersion(bool enable)

--- a/cpp/skyweaver/src/PipelineConfig.cpp
+++ b/cpp/skyweaver/src/PipelineConfig.cpp
@@ -185,31 +185,33 @@ void PipelineConfig::configure_wait(std::string argument)
     _wait.is_enabled = true;
     while (std::getline(tokenStream, token, ':')) {
         if(indx == 0)
+        {
             errno = 0;
             _wait.iterations = std::stoi(token);
             if (errno == ERANGE) {
               throw std::runtime_error("Wait iteration number out of range!");
             }
             if (_wait.iterations < 0) _wait.iterations = 0;
-        else if(indx == 1)
+        } else if(indx == 1) {
             errno = 0;
             _wait.sleep_time = std::stoi(token);
             if (errno == ERANGE) {
               throw std::runtime_error("Sleep time out of range!");
             }
             if (_wait.sleep_time < 1) _wait.sleep_time = 1;
-        else if(indx == 2)
+        } else if(indx == 2) {
             if (!token.empty() && std::all_of(token.begin(), token.end(), ::isdigit))
             {
-               _wait.min_free_space = std::stoull(token);
+                _wait.min_free_space = std::stoull(token);
             } else {
-              try {
-                _wait.min_free_space = convertMemorySize(token);
-              } catch (std::runtime_error& e) {
-                std::cout << "Memory conversion error: " << e.what() << std::endl;
-            throw;
-        }
+                try {
+                    _wait.min_free_space = convertMemorySize(token);
+                } catch (std::runtime_error& e) {
+                    std::cout << "Memory conversion error: " << e.what() << std::endl;
+                    throw;
+                }
             }
+        }
         indx++;
     }
 }

--- a/cpp/skyweaver/src/PipelineConfig.cpp
+++ b/cpp/skyweaver/src/PipelineConfig.cpp
@@ -15,7 +15,7 @@ PipelineConfig::PipelineConfig()
       _bw(13375000.0), _channel_frequencies_stale(true),
       _gulp_length_samps(4096), _start_time(0.0f),
       _duration(std::numeric_limits<float>::infinity()), _total_nchans(4096),
-      _stokes_mode("I"), _output_level(24.0f)
+      _stokes_mode("I"), _output_level(24.0f), _wait({false, 0, 0, 0})
 {
 }
 

--- a/cpp/skyweaver/src/PipelineConfig.cpp
+++ b/cpp/skyweaver/src/PipelineConfig.cpp
@@ -173,7 +173,7 @@ std::size_t PipelineConfig::convertMemorySize(const std::string& str) const {
     else if (unitPart == "G" || unitPart == "g")
         return number * 1024 * 1024 * 1024;
     else
-        throw std::runtime_error("Invalid unit!");
+        throw std::runtime_error("Invalid memory unit!");
 }
 
 void PipelineConfig::configure_wait(std::string argument)
@@ -185,15 +185,30 @@ void PipelineConfig::configure_wait(std::string argument)
     _wait.is_enabled = true;
     while (std::getline(tokenStream, token, ':')) {
         if(indx == 0)
+            errno = 0;
             _wait.iterations = std::stoi(token);
+            if (errno == ERANGE) {
+              throw std::runtime_error("Wait iteration number out of range!");
+            }
+            if (_wait.iterations < 0) _wait.iterations = 0;
         else if(indx == 1)
+            errno = 0;
             _wait.sleep_time = std::stoi(token);
+            if (errno == ERANGE) {
+              throw std::runtime_error("Sleep time out of range!");
+            }
+            if (_wait.sleep_time < 1) _wait.sleep_time = 1;
         else if(indx == 2)
             if (!token.empty() && std::all_of(token.begin(), token.end(), ::isdigit))
             {
                _wait.min_free_space = std::stoull(token);
             } else {
-               _wait.min_free_space = convertMemorySize(token);
+              try {
+                _wait.min_free_space = convertMemorySize(token);
+              } catch (std::runtime_error& e) {
+                std::cout << "Memory conversion error: " << e.what() << std::endl;
+            throw;
+        }
             }
         indx++;
     }

--- a/cpp/skyweaver/src/skyweaver_cli.cu
+++ b/cpp/skyweaver/src/skyweaver_cli.cu
@@ -447,7 +447,20 @@ int main(int argc, char** argv)
                  [](std::size_t nthreads) { omp_set_num_threads(nthreads); }),
              "The number of threads to use for incoherent dedispersion")
 
-            // Logging options
+            ("wait-for-space",
+              po::value<std::vector<std::string>>()
+                 ->multitoken()
+                 ->required()
+                 ->notifier(
+                     [&config](std::vector<std::string> const& descriptors) {
+                         for(auto const& descriptor: descriptors) {
+                             config.configure_wait(descriptor);
+                         }
+                     }),
+             "Wait for enough disk space for the output. "
+             "(<nr_of_cycles (0 for infinity)>:<sleep_time_per_cycle [s]>:<minimum_size(e.g. 200M or 32G)>")
+
+          // Logging options
             ("log-level",
              po::value<std::string>()->default_value("info")->notifier(
                  [](std::string level) { skyweaver::set_log_level(level); }),

--- a/cpp/skyweaver/src/skyweaver_cli.cu
+++ b/cpp/skyweaver/src/skyweaver_cli.cu
@@ -448,17 +448,11 @@ int main(int argc, char** argv)
              "The number of threads to use for incoherent dedispersion")
 
             ("wait-for-space",
-              po::value<std::vector<std::string>>()
-                 ->multitoken()
-                 ->required()
+              po::value<std::string>()
                  ->notifier(
-                     [&config](std::vector<std::string> const& descriptors) {
-                         for(auto const& descriptor: descriptors) {
-                             config.configure_wait(descriptor);
-                         }
-                     }),
+                     [&config](std::string key) { config.configure_wait(key); }),
              "Wait for enough disk space for the output. "
-             "(<nr_of_cycles (0 for infinity)>:<sleep_time_per_cycle [s]>:<minimum_size(e.g. 200M or 32G)>")
+             "<nr_of_cycles (0 for infinity)>:<sleep_time_per_cycle [s]>:<minimum_size(e.g. 200M or 32G)>")
 
           // Logging options
             ("log-level",


### PR DESCRIPTION
This doesn't add much overhead and helps us to write the output to the ramdisk, which needs to cleaned frequently. If the cleaning process can't catch up, the beamformer waits.

There are two open questions:
- Do we want to introduce a flag to turn this on or off? What would be the default then?
- Do we want to set the sleep time via the CLI?

Answering one or both questions with yes requires some additional code changes on the CLI argument list.