### PR TITLE
Add .tmp suffix to output filenames, and remove it when they are closed.

### DIFF
--- a/cpp/skyweaver/FileOutputStream.hpp
+++ b/cpp/skyweaver/FileOutputStream.hpp
@@ -48,6 +48,8 @@ class FileOutputStream
         std::string _full_path;
         std::size_t _bytes_requested;
         std::size_t _bytes_written;
+        std::string _temporary_suffix;
+        std::string _temporary_path;
         std::ofstream _stream;
     };
 


### PR DESCRIPTION
Adds a temporary suffix to all output files to indicate writing in progress. This is then removed when the file is closed. 