### PR TITLE
Filename frequency fix

### DIFF
--- a/cpp/skyweaver/detail/file_writer_callbacks.cpp
+++ b/cpp/skyweaver/detail/file_writer_callbacks.cpp
@@ -87,12 +87,12 @@ create_dada_file_stream(MultiFileWriterConfig const& config,
 
     std::stringstream output_dir;
     output_dir << config.output_dir << "/" << std::fixed << std::setfill('0')
-               << std::setw(9) << static_cast<int>(header.frequency);
+               << std::setw(9) << static_cast<std::size_t>(header.frequency);
 
     std::stringstream output_basename;
     output_basename << config.output_basename << "_" << std::fixed
                     << std::setfill('0') << std::setw(9)
-                    << static_cast<int>(header.frequency);
+                    << static_cast<std::size_t>(header.frequency);
 
     std::unique_ptr<FileOutputStream> file_stream =
         std::make_unique<FileOutputStream>(


### PR DESCRIPTION
Due to an integer overflow, S-band frequencies in skyweaver output files were incorrect:
e.g.
```
$ ls 2024-12-07-10\:50\:35/0/-2147483648/
2024-12-07-10:50:35_0_cdm_00000.000_stats_-2147483648_0000000000000000.fpa.tmp
2024-12-07-10:50:35_0_cdm_00050.372_cb_-2147483648_0000000000000000.tfb.tmp
2024-12-07-10:50:35_0_cdm_00050.372_cb_-2147483648_0000000000000000.tdb.tmp
2024-12-07-10:50:35_0_cdm_00050.372_ib_-2147483648_0000000000000000.btf.tmp
```

Changing to `std::size_t` instead of `int` fixes this:
```
$ ls 2024-12-07-10\:50\:35/0/2549697875/
2024-12-07-10:50:35_0_cdm_00000.000_stats_2549697875_0000000000000000.fpa.tmp
2024-12-07-10:50:35_0_cdm_00050.372_cb_2549697875_0000000000000000.tfb.tmp
2024-12-07-10:50:35_0_cdm_00050.372_ib_2549697875_0000000000000000.btf.tmp
```