### PR TITLE
Optional output of stats and incoherent beam files

### DIFF
--- a/cpp/skyweaver/PipelineConfig.hpp
+++ b/cpp/skyweaver/PipelineConfig.hpp
@@ -165,7 +165,6 @@ class PipelineConfig
      */
     bool enable_incoherent_dedispersion() const;
 
-
     /**
      * @brief      Enable/disable calculation and writing of voltage statistics
      */
@@ -175,6 +174,16 @@ class PipelineConfig
      * @brief      Check if calculation of voltage statistics is enabled
      */
     bool output_statistics() const;
+
+    /**
+     * @brief      Enable/disable writing out the incoherent beam
+     */
+    void output_incoherent_beam(bool enable);
+
+    /**
+     * @brief      Check if outputting incoherent beam is enabled
+     */
+    bool output_incoherent_beam() const;
 
     /**
      * @brief      Return the number of time samples to be integrated
@@ -351,6 +360,7 @@ class PipelineConfig
     std::string _output_file_prefix;
     bool _enable_incoherent_dedispersion;
     bool _output_statistics;
+    bool _output_incoherent_beam;
     double _cfreq;
     double _bw;
     mutable bool _channel_frequencies_stale;

--- a/cpp/skyweaver/PipelineConfig.hpp
+++ b/cpp/skyweaver/PipelineConfig.hpp
@@ -165,6 +165,17 @@ class PipelineConfig
      */
     bool enable_incoherent_dedispersion() const;
 
+
+    /**
+     * @brief      Enable/disable calculation and writing of voltage statistics
+     */
+    void output_statistics(bool enable);
+
+    /**
+     * @brief      Check if calculation of voltage statistics is enabled
+     */
+    bool output_statistics() const;
+
     /**
      * @brief      Return the number of time samples to be integrated
      *             in the coherent beamformer.
@@ -339,6 +350,7 @@ class PipelineConfig
     std::size_t _max_output_filesize;
     std::string _output_file_prefix;
     bool _enable_incoherent_dedispersion;
+    bool _output_statistics;
     double _cfreq;
     double _bw;
     mutable bool _channel_frequencies_stale;

--- a/cpp/skyweaver/detail/BeamformerPipeline.cu
+++ b/cpp/skyweaver/detail/BeamformerPipeline.cu
@@ -115,7 +115,10 @@ void BeamformerPipeline<CBHandler, IBHandler, StatsHandler, BeamformerTraits>::
     _utc_offset = utc_offset;
     _cb_handler.init(_header);
     _ib_handler.init(_header);
-    _stats_handler.init(_header);
+    if (_config.output_statistics())
+    {
+	_stats_handler.init(_header);
+    }
     NVTX_RANGE_POP();
 }
 
@@ -161,20 +164,23 @@ void BeamformerPipeline<CBHandler, IBHandler, StatsHandler, BeamformerTraits>::
     _timer.stop("transpose TAFTP to FTPA");
     NVTX_RANGE_POP();
 
-    NVTX_RANGE_PUSH("Calculate statistics");
-    BOOST_LOG_TRIVIAL(debug) << "Checking if channel statistics update request";
-    _timer.start("calculate statistics");
-    _stats_manager->calculate_statistics(_ftpa_post_transpose);
-    _timer.stop("calculate statistics");
-    NVTX_RANGE_POP();
-    NVTX_RANGE_PUSH("Update scalings");
-    if(_call_count == 0) {
+    if ((_call_count == 0) || _config.output_statistics())
+    {
+      NVTX_RANGE_PUSH("Calculate statistics");
+      BOOST_LOG_TRIVIAL(debug) << "Checking if channel statistics update request";
+      _timer.start("calculate statistics");
+      _stats_manager->calculate_statistics(_ftpa_post_transpose);
+      _timer.stop("calculate statistics");
+      NVTX_RANGE_POP();
+      if(_call_count == 0) {
+        NVTX_RANGE_PUSH("Update scalings");
         _timer.start("update scalings");
         _stats_manager->update_scalings(_delay_manager->beamset_weights(),
                                         _delay_manager->nbeamsets());
         _timer.stop("update scalings");
+        NVTX_RANGE_POP();
+      }
     }
-    NVTX_RANGE_POP();
     // BOOST_LOG_TRIVIAL(debug) << "Peeking the statistics";
     // peek(_stats_manager->statistics(), 64);
 
@@ -251,11 +257,14 @@ void BeamformerPipeline<CBHandler, IBHandler, StatsHandler, BeamformerTraits>::
         NVTX_RANGE_POP();
     }
     NVTX_RANGE_POP();
-    NVTX_RANGE_PUSH("Stats handler");
-    _timer.start("statistics handler");
-    _stats_handler(_stats_manager->statistics());
-    _timer.stop("statistics handler");
-    NVTX_RANGE_POP();
+    if (_config.output_statistics())
+    {
+      NVTX_RANGE_PUSH("Stats handler");
+      _timer.start("statistics handler");
+      _stats_handler(_stats_manager->statistics());
+      _timer.stop("statistics handler");
+      NVTX_RANGE_POP();
+    }
     NVTX_RANGE_POP();
 }
 

--- a/cpp/skyweaver/detail/BeamformerPipeline.cu
+++ b/cpp/skyweaver/detail/BeamformerPipeline.cu
@@ -114,7 +114,10 @@ void BeamformerPipeline<CBHandler, IBHandler, StatsHandler, BeamformerTraits>::
     _header     = header;
     _utc_offset = utc_offset;
     _cb_handler.init(_header);
-    _ib_handler.init(_header);
+    if (_config.output_incoherent_beam())
+    {
+      _ib_handler.init(_header);
+    }
     if (_config.output_statistics())
     {
 	_stats_handler.init(_header);
@@ -250,11 +253,14 @@ void BeamformerPipeline<CBHandler, IBHandler, StatsHandler, BeamformerTraits>::
         _timer.stop("coherent beam handler");
         NVTX_RANGE_POP();
 
-        NVTX_RANGE_PUSH("Incoherent beamformer handler");
-        _timer.start("incoherent beam handler");
-        _ib_handler(_tf_ib, dm_idx);
-        _timer.stop("incoherent beam handler");
-        NVTX_RANGE_POP();
+	if (_config.output_incoherent_beam())
+	{
+          NVTX_RANGE_PUSH("Incoherent beamformer handler");
+          _timer.start("incoherent beam handler");
+          _ib_handler(_tf_ib, dm_idx);
+          _timer.stop("incoherent beam handler");
+          NVTX_RANGE_POP();
+	}
     }
     NVTX_RANGE_POP();
     if (_config.output_statistics())

--- a/cpp/skyweaver/src/PipelineConfig.cpp
+++ b/cpp/skyweaver/src/PipelineConfig.cpp
@@ -15,7 +15,7 @@ PipelineConfig::PipelineConfig()
       _bw(13375000.0), _channel_frequencies_stale(true),
       _gulp_length_samps(4096), _start_time(0.0f),
       _duration(std::numeric_limits<float>::infinity()), _total_nchans(4096),
-      _stokes_mode("I"), _output_level(24.0f)
+      _stokes_mode("I"), _output_level(24.0f), _output_statistics(true)
 {
 }
 
@@ -167,6 +167,16 @@ void PipelineConfig::enable_incoherent_dedispersion(bool enable)
 bool PipelineConfig::enable_incoherent_dedispersion() const
 {
     return _enable_incoherent_dedispersion;
+}
+
+void PipelineConfig::output_statistics(bool enable)
+{
+    _output_statistics = enable;
+}
+
+bool PipelineConfig::output_statistics() const
+{
+    return _output_statistics;
 }
 
 std::vector<double> const& PipelineConfig::channel_frequencies() const

--- a/cpp/skyweaver/src/PipelineConfig.cpp
+++ b/cpp/skyweaver/src/PipelineConfig.cpp
@@ -15,7 +15,7 @@ PipelineConfig::PipelineConfig()
       _bw(13375000.0), _channel_frequencies_stale(true),
       _gulp_length_samps(4096), _start_time(0.0f),
       _duration(std::numeric_limits<float>::infinity()), _total_nchans(4096),
-      _stokes_mode("I"), _output_level(24.0f), _output_statistics(true)
+      _stokes_mode("I"), _output_level(24.0f), _output_statistics(true), _output_incoherent_beam(true)
 {
 }
 
@@ -177,6 +177,16 @@ void PipelineConfig::output_statistics(bool enable)
 bool PipelineConfig::output_statistics() const
 {
     return _output_statistics;
+}
+
+void PipelineConfig::output_incoherent_beam(bool enable)
+{
+    _output_incoherent_beam = enable;
+}
+
+bool PipelineConfig::output_incoherent_beam() const
+{
+    return _output_incoherent_beam;
 }
 
 std::vector<double> const& PipelineConfig::channel_frequencies() const

--- a/cpp/skyweaver/src/skyweaver_cli.cu
+++ b/cpp/skyweaver/src/skyweaver_cli.cu
@@ -476,7 +476,14 @@ int main(int argc, char** argv)
             ("log-level",
              po::value<std::string>()->default_value("info")->notifier(
                  [](std::string level) { skyweaver::set_log_level(level); }),
-             "The logging level to use (debug, info, warning, error)");
+             "The logging level to use (debug, info, warning, error)")
+
+	    ("statistics",
+             po::value<bool>()->default_value(true)->notifier(
+		  [&config](bool const& enable) {
+                         config.output_statistics(enable); }),
+	     "Turn on/off calculation and output of voltage statistics");
+
 
         // set options allowed on command line
         po::options_description cmdline_options;

--- a/cpp/skyweaver/src/skyweaver_cli.cu
+++ b/cpp/skyweaver/src/skyweaver_cli.cu
@@ -482,8 +482,14 @@ int main(int argc, char** argv)
              po::value<bool>()->default_value(true)->notifier(
 		  [&config](bool const& enable) {
                          config.output_statistics(enable); }),
-	     "Turn on/off calculation and output of voltage statistics");
+	     "Turn on/off calculation and output of voltage statistics")
 
+	    ("write-incoherent-beam",
+             po::value<bool>()->default_value(true)->notifier(
+		  [&config](bool const& enable) {
+                         config.output_incoherent_beam(enable); }),
+	     "Turn on/off output of incoherent beam"
+	     "Turning off does not disable incoherent beam subtraction");
 
         // set options allowed on command line
         po::options_description cmdline_options;


### PR DESCRIPTION
Added command line options to disable outputting the voltages statistics and incoherent beam files. If stats output is turned off, the stats are also not calculated, saving some GPU time. 