### PR TITLE
Skycleaver tdb order fix

### DIFF
--- a/cpp/skyweaver/detail/SkyCleaver.cpp
+++ b/cpp/skyweaver/detail/SkyCleaver.cpp
@@ -102,6 +102,8 @@ std::vector<std::string> get_files(std::string directory_path,
                            directory_path);
     }
 
+    std::sort(files.begin(), files.end());
+
     return files;
 }
 

--- a/cpp/skyweaver/detail/SkyCleaver.cpp
+++ b/cpp/skyweaver/detail/SkyCleaver.cpp
@@ -303,7 +303,7 @@ void skyweaver::SkyCleaver<InputVectorType, OutputVectorType>::init_readers()
     long double start_freq = obs_centre_freq - obs_bandwidth / 2;
 
     for(int i = 0; i < _config.nbridges(); i++) {
-        int ifreq = std::lround(std::floor(
+      std::size_t ifreq = std::lround(std::floor(
             start_freq + (i + 0.5) * obs_bandwidth / _config.nbridges()));
         _expected_freqs.push_back(ifreq);
         BOOST_LOG_TRIVIAL(info)


### PR DESCRIPTION
If the output from skyweaver is split into several files by time (by reducing the maximum output file size), then skycleaver reads the resulting .tdb files in a random order. 

This solves the problem by just sorting the files alphabetically, but perhaps some file contiguity checks might be required to be more thorough about this. 